### PR TITLE
add ci for publish to trunk

### DIFF
--- a/.github/workflows/extension_release.yml
+++ b/.github/workflows/extension_release.yml
@@ -1,0 +1,85 @@
+name: Release pg_auto_dwh
+
+defaults:
+  run:
+    shell: bash
+    working-directory: ./extension
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - "README.md"
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "README.md"
+  release:
+    types:
+      - created
+jobs:
+  dependencies:
+    name: Install dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          cache-directories: /home/runner/.pgrx
+
+      - name: Install stoml and pg-trunk
+        shell: bash
+        run: |
+          set -xe
+          wget https://github.com/freshautomations/stoml/releases/download/v0.7.1/stoml_linux_amd64 &> /dev/null
+          mv stoml_linux_amd64 stoml
+          chmod +x stoml
+          sudo mv stoml /usr/local/bin/
+          cargo install pg-trunk
+
+      - name: Cache binaries
+        uses: actions/cache@v2
+        with:
+          path: |
+            /usr/local/bin/stoml
+            ~/.cargo/bin/trunk
+          key: ${{ runner.os }}-bins-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-bins-
+
+  publish:
+    if: github.event_name == 'release'
+    name: trunk publish
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        pg-version: [14, 15, 16]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Install stoml and pg-trunk
+        shell: bash
+        run: |
+          set -xe
+          wget https://github.com/freshautomations/stoml/releases/download/v0.7.1/stoml_linux_amd64 &> /dev/null
+          mv stoml_linux_amd64 stoml
+          chmod +x stoml
+          sudo mv stoml /usr/local/bin/
+          cargo install pg-trunk
+      - name: trunk build
+        working-directory: ./extension
+        run: |
+          ~/.cargo/bin/trunk build --pg-version ${{ matrix.pg-version }}
+      - name: trunk publish
+        working-directory: ./extension
+        env:
+          TRUNK_API_TOKEN: ${{ secrets.TRUNK_AUTH_TOKEN }}
+        run: ~/.cargo/bin/trunk publish

--- a/.github/workflows/extension_release.yml
+++ b/.github/workflows/extension_release.yml
@@ -1,4 +1,4 @@
-name: Release pg_auto_dwh
+name: Release pg_auto_dw
 
 defaults:
   run:
@@ -20,40 +20,8 @@ on:
     types:
       - created
 jobs:
-  dependencies:
-    name: Install dependencies
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          cache-directories: /home/runner/.pgrx
-
-      - name: Install stoml and pg-trunk
-        shell: bash
-        run: |
-          set -xe
-          wget https://github.com/freshautomations/stoml/releases/download/v0.7.1/stoml_linux_amd64 &> /dev/null
-          mv stoml_linux_amd64 stoml
-          chmod +x stoml
-          sudo mv stoml /usr/local/bin/
-          cargo install pg-trunk
-
-      - name: Cache binaries
-        uses: actions/cache@v2
-        with:
-          path: |
-            /usr/local/bin/stoml
-            ~/.cargo/bin/trunk
-          key: ${{ runner.os }}-bins-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-bins-
-
   publish:
-    if: github.event_name == 'release'
+    # if: github.event_name == 'release'
     name: trunk publish
     runs-on: ubuntu-latest
     strategy:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing to `pg_auto_dw`
+
+## Releases
+
+`pg_auto_dw` follows [semantic versioning](semver.org) and is released to [pgt.dev](https://pgt.dev/extensions/pg_auto_dw).
+
+To release, follow these steps:
+
+1. Create a PR updating the version in `Cargo.toml` and `Trunk.toml`. These two values must agree.
+2. Merge the PR into the `main` branch.
+3. [Create the release](https://github.com/tembo-io/pg_auto_dw/releases/new)
+   1. Use the tag format `vX.Y.Z` where `X.Y.Z` is the version number. e.g. `v0.1.0`. This version should be the same value as in `Cargo.toml` and `Trunk.toml`.
+   2. Click "Generated release notes" to auto-populate the release notes or fill in with your own content and notes.
+   3. Click "Publish release"

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ We want to make building a data warehouse easy.  And, if the source tables are w
 1. **Install Extension**
 ```SQL
 /* Installing Extension - Installs and creates sample source tables. */
-CREATE EXTENSION pg_auto_dw;
+CREATE EXTENSION pg_auto_dw CASCADE;
 ```
 > **Note:** Installing this extension installs a couple source sample tables in the PUBLIC SCHEMA as well as the PG_CRYPTO extension.
 2. **Build Data Warehouse**

--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -1,16 +1,13 @@
 [package]
 name = "pg_auto_dw"
-version = "0.0.0"
+version = "0.0.1"
 edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]
 
 [features]
-default = ["pg13"]
-pg11 = ["pgrx/pg11", "pgrx-tests/pg11" ]
-pg12 = ["pgrx/pg12", "pgrx-tests/pg12" ]
-pg13 = ["pgrx/pg13", "pgrx-tests/pg13" ]
+default = ["pg16"]
 pg14 = ["pgrx/pg14", "pgrx-tests/pg14" ]
 pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
 pg16 = ["pgrx/pg16", "pgrx-tests/pg16" ]

--- a/extension/Trunk.toml
+++ b/extension/Trunk.toml
@@ -1,0 +1,14 @@
+[extension]
+name = "pg_auto_dw"
+version = "0.0.1"
+repository = "https://github.com/tembo-io/pg_auto_dw"
+license = "PostgreSQL"
+description = "An auto data warehouse extension for Postgres."
+homepage = "https://github.com/tembo-io/pg_auto_dw"
+documentation = "https://github.com/tembo-io/pg_auto_dw"
+categories = ["analytics", "orchestration"]
+loadable_libraries = [{ library_name = "pg_auto_dw", requires_restart = true }]
+
+[build]
+postgres_version = "15"
+platform = "linux/amd64"


### PR DESCRIPTION
Adds a github workflow for publishing to pgt.dev, + instructions for how to trigger those releases in `CONTRIBUTING.md`.