### PR TITLE
Fix: GUC Database Utilization for Background Transformer Function

### DIFF
--- a/extension/src/utility/sql/info_tables.sql
+++ b/extension/src/utility/sql/info_tables.sql
@@ -64,3 +64,13 @@ CREATE TABLE dv_repo (
     insert_time  TIMESTAMP WITHOUT TIME ZONE DEFAULT (now() AT TIME ZONE 'UTC'),
     schema JSON
 );
+
+DROP TABLE IF EXISTS log;
+
+CREATE TABLE log (
+    pk_log BIGSERIAL PRIMARY KEY,      
+    log_ts TIMESTAMP WITHOUT TIME ZONE DEFAULT (NOW() AT TIME ZONE 'UTC'),
+    process VARCHAR(50),
+	level VARCHAR(50),
+    message TEXT     
+);


### PR DESCRIPTION
The include and exclude functions were identified as correct; however, during testing on Tembo, it was discovered that the database name was not being utilized in the background transformer and had been hardcoded as PG_AUTO_DW. The GUC for the background transformer is now correctly implemented and has been tested.