### PR TITLE
Optimized SHA-256 Hash Function for Performance and Parallelism

### DIFF
--- a/extension/src/lib.rs
+++ b/extension/src/lib.rs
@@ -137,11 +137,9 @@ fn source_column() -> Result<
     .map(TableIterator::new)
 }
 
-#[pg_extern]
-fn hash(inputs: &str) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(inputs.as_bytes());
-    let digest = hasher.finalize();
+#[pg_extern(immutable, parallel_safe)]
+fn hash(input: &str) -> String {
+    let digest = Sha256::digest(input.as_bytes());
     hex::encode(digest)
 }
 


### PR DESCRIPTION
Function immutability and parallel execution were indicated. Additionally, the function was simplified.

Initial testing indicates comparable or better performance running in serial or parallel compared to the native sha256 function.  Testing was completed within the PGRX Postgres 16 instance; however, more testing is needed to validate superior performance.

```SQL
-- Performance Test
DROP TABLE IF EXISTS random_text_data;
CREATE TABLE random_text_data (
    random_text TEXT
);
CREATE INDEX idx_random_text ON random_text_data (random_text);

INSERT INTO random_text_data (random_text)
SELECT encode(sha256(convert_to(generate_series::varchar, 'UTF8')), 'hex') as random_text
FROM generate_series(1, 1000000);

SHOW max_parallel_workers_per_gather;
SHOW max_parallel_workers;
SHOW max_worker_processes;
SHOW parallel_setup_cost;
SHOW parallel_tuple_cost;

SET max_parallel_workers_per_gather = 4;
SET max_parallel_workers = 8;
SET parallel_setup_cost = 0;
SET parallel_tuple_cost = 0;

VACUUM ANALYZE random_text_data;

-- Initial Indication of speedup of 40%+ vs native function
SELECT proname, proparallel, provolatile, procost FROM pg_proc WHERE proname = 'hash';
EXPLAIN ANALYZE
SELECT auto_dw.hash(random_text) 
FROM random_text_data; --1.082s, 0.918s, 0.939s per 1M records

SELECT proname, proparallel, provolatile, procost FROM pg_proc WHERE proname = 'sha256';
EXPLAIN ANALYZE
SELECT encode(sha256(convert_to(random_text, 'UTF8')), 'hex')
FROM random_text_data; -- 1.485s, 1.910s, 1.844 per 1M records
```