### PR TITLE
Feature/PADW-69 Support for FDW

### DIFF
--- a/extension/src/controller/bgw_transformer_client.rs
+++ b/extension/src/controller/bgw_transformer_client.rs
@@ -218,7 +218,11 @@ pub extern "C" fn background_worker_transformer_client(_arg: pg_sys::Datum) {
                     if column == &identified_business_key.identified_business_key_values.column_no {
 
                         let category = "Business Key Part";
-                        let confidence_score = identified_business_key.identified_business_key_values.confidence_value * business_key_name.business_key_name_values.confidence_value;
+                        // Calculate the overall confidence score by taking the minimum of the confidence values
+                        // for the identified business key and the business key name. This approach is chosen to 
+                        // ensure that the overall confidence reflects the weakest link, avoiding inflation of 
+                        // the confidence score when one value is significantly lower than the other.
+                        let confidence_score = identified_business_key.identified_business_key_values.confidence_value.min(business_key_name.business_key_name_values.confidence_value);
                         let bk_name = &business_key_name.business_key_name_values.name;
                         let bk_identified_reason = &identified_business_key.identified_business_key_values.reason;
                         let bk_name_reason = &business_key_name.business_key_name_values.reason;

--- a/extension/src/model/queries.rs
+++ b/extension/src/model/queries.rs
@@ -88,7 +88,7 @@ table_qry AS (
 	LEFT JOIN pg_catalog.pg_description ON 	pg_class.oid = pg_description.objoid AND 
 											pg_description.objsubid = 0 -- No Sub Objects
 	WHERE 
-		pg_class.relkind = 'r'  -- 'r' stands for ordinary table
+		pg_class.relkind IN  ('r', 'f')  -- 'r' stands for ordinary table, 'f' stands for foreign data wrapper
 ),
 column_qry AS (
 	SELECT 
@@ -534,7 +534,7 @@ pub fn get_column_data(schema_name: &str, table_name: &str, column_name: &str) -
 			LEFT JOIN pg_catalog.pg_description ON 	pg_class.oid = pg_description.objoid AND 
 													pg_description.objsubid = 0 -- No Sub Objects
 			WHERE 
-				pg_class.relkind = 'r'  -- 'r' stands for ordinary table
+				pg_class.relkind IN  ('r', 'f')  -- 'r' stands for ordinary table, 'f' stands for foreign data wrapper
 		),
 		column_qry AS (
 			SELECT 


### PR DESCRIPTION
This pull request introduces support for Foreign Data Wrapper (FDW) tables and improves the calculation of confidence scores for business keys, enhancing system flexibility and accuracy.

**FDW Support**
- Added functionality to integrate FDW tables, enabling seamless access to external data sources through the database.

**Confidence Score Calculation Update:**
- Refactored the business key confidence calculation to use the minimum confidence value between the identified business key and its name.
- This change prevents the overall confidence score from being deflated via score multiplication.