### PR TITLE
Feature/padw 75 identify all business key components

### DIFF
--- a/extension/src/controller/bgw_transformer_client.rs
+++ b/extension/src/controller/bgw_transformer_client.rs
@@ -347,22 +347,6 @@ struct BusinessKeyComponentIdentificationValues {
 }
 
 #[derive(Deserialize, Debug)]
-struct IdentifiedBusinessKey {
-    #[serde(rename = "Identified Business Key")]
-    identified_business_key_values: IdentifiedBusinessKeyValues,
-}
-
-#[derive(Deserialize, Debug)]
-struct IdentifiedBusinessKeyValues {
-    #[serde(rename = "Column No")]
-    column_no: u32,
-    #[serde(rename = "Confidence Value")]
-    confidence_value: f64,
-    #[serde(rename = "Reason")]
-    reason: String,
-}
-
-#[derive(Deserialize, Debug)]
 struct BusinessKeyName {
     #[serde(rename = "Business Key Name")]
     business_key_name_values: BusinessKeyNameValues,

--- a/extension/src/controller/bgw_transformer_client.rs
+++ b/extension/src/controller/bgw_transformer_client.rs
@@ -163,94 +163,6 @@ pub extern "C" fn background_worker_transformer_client(_arg: pg_sys::Datum) {
                     }
                 }
 
-                // Identity BK Ordinal Location
-                let mut generation_json_bk_identification: Option<serde_json::Value> = None;
-                let mut identified_business_key_opt: Option<IdentifiedBusinessKey> = None;
-                let mut retries = 0;
-                let mut hints = String::new();
-                while retries < MAX_TRANSFORMER_RETRIES {
-                    runtime.block_on(async {
-                        // Get Generation
-                        generation_json_bk_identification = match transformer_client::send_request(table_details_json_str.as_str(), prompt_template::PromptTemplate::BKIdentification, &0, &hints).await {
-                            Ok(response_json) => {
-                                Some(response_json)
-                            },
-                            Err(e) => {
-                                log!("Error in transformer request, malformed or timed out: {}", e);
-                                hints = format!("Hint: Please ensure you provide a JSON response only.  This is your {} attempt.", retries + 1);
-                                None
-                            }
-                        };
-                    });
-
-                    if generation_json_bk_identification.is_none() {
-                        retries += 1;
-                        continue; // Skip to the next iteration
-                    }
-
-                    match serde_json::from_value::<IdentifiedBusinessKey>(generation_json_bk_identification.clone().unwrap()) {
-                        Ok(bk) => {
-                            identified_business_key_opt = Some(bk);
-                            break; // Successfully Decoded
-                        }
-                        Err(e) => {
-                            log!("Error JSON JSON Structure not of type IdentifiedBusinessKey: {}", e);
-                            hints = format!("Hint: Please ensure the correct JSON key pair structure is given.  Previously you gave a response but it errored.  Error: {e}. Please try again.");
-                        }
-                    }
-                    retries += 1;
-                }
-
-                let identified_business_key = match identified_business_key_opt {
-                    Some(bk) => bk,
-                    None => panic!("Failed to identify business key after {} retries", retries),
-                };
-
-                // Identity BK Name
-                let mut generation_json_bk_name: Option<serde_json::Value> = None;
-                let mut business_key_name_opt: Option<BusinessKeyName> = None;
-                let mut retries = 0;
-                let mut hints = String::new();
-                while retries < MAX_TRANSFORMER_RETRIES {
-                    runtime.block_on(async {
-                        // Get Generation
-                        generation_json_bk_name = match transformer_client::send_request(table_details_json_str.as_str(), prompt_template::PromptTemplate::BKName, &0, &hints).await {
-                            Ok(response_json) => {
-                                
-                                // let response_json_pretty = serde_json::to_string_pretty(&response_json)
-                                //                                                     .expect("Failed to convert Response JSON to Pretty String.");
-                                Some(response_json)
-                            },
-                            Err(e) => {
-                                log!("Error in transformer request, malformed or timed out: {}", e);
-                                hints = format!("Hint: Please ensure you provide a JSON response only.  This is your {} attempt.", retries + 1);
-                                None
-                            }
-                        };
-                    });
-
-                    if generation_json_bk_name.is_none() {
-                        retries += 1;
-                        continue; // Skip to the next iteration
-                    }
-
-                    match serde_json::from_value::<BusinessKeyName>(generation_json_bk_name.clone().unwrap()) {
-                        Ok(bk) => {
-                            business_key_name_opt = Some(bk);
-                            break; // Successfully Decoded
-                        }
-                        Err(e) => {
-                            log!("Error JSON JSON Structure not of type BusinessKeyName: {}", e);
-                        }
-                    }
-                    retries += 1;
-                }
-
-                let business_key_name = match business_key_name_opt {
-                    Some(bk) => bk,
-                    None => panic!("Failed to identify business key name after {} retries", retries),
-                };
-
                 // Identity Descriptor - Sensitive
                 // let mut generation_json_descriptors_sensitive: HashMap<&u32, Option<serde_json::Value>> = HashMap::new();
                 let mut descriptors_sensitive: HashMap<&u32, DescriptorSensitive> = HashMap::new();
@@ -269,10 +181,6 @@ pub extern "C" fn background_worker_transformer_client(_arg: pg_sys::Datum) {
                                     column, 
                                     &hints).await {
                                 Ok(response_json) => {
-                                    
-                                    // let response_json_pretty = serde_json::to_string_pretty(&response_json)
-                                    //                                                     .expect("Failed to convert Response JSON to Pretty String.");
-
                                     Some(response_json)
                                 },
                                 Err(e) => {
@@ -313,67 +221,70 @@ pub extern "C" fn background_worker_transformer_client(_arg: pg_sys::Datum) {
 
                     let last = {index == table_column_links.column_links.len() - 1};
 
-                    if column == &identified_business_key.identified_business_key_values.column_no {
+                    match (business_key_component_identification.get(column), business_key_name.get(column)) {
+                        (Some(business_key_component_identification), Some(business_key_name)) => {
+                            let category = "Business Key Part";
+                            // Calculate the overall confidence score by taking the minimum of the confidence values
+                            // for the identified business key and the business key name. This approach is chosen to 
+                            // ensure that the overall confidence reflects the weakest link, avoiding inflation of 
+                            // the confidence score when one value is significantly lower than the other.
+                            let confidence_score = 
+                                business_key_component_identification.business_key_component_identification.confidence_value.min(
+                                    business_key_name.business_key_name_values.confidence_value);
+                            let bk_name = &business_key_name.business_key_name_values.name;
+                            let bk_identified_reason = &business_key_component_identification.business_key_component_identification.reason;
+                            let bk_name_reason = &business_key_name.business_key_name_values.reason;
+                            let reason = format!("BK Identified Reason: {}, BK Naming Reason: {}", bk_identified_reason, bk_name_reason);
+                            let model_name_owned = guc::get_guc(guc::PgAutoDWGuc::Model).expect("MODEL GUC is not set.");
+                            let model_name = model_name_owned.as_str();
 
-                        let category = "Business Key Part";
-                        // Calculate the overall confidence score by taking the minimum of the confidence values
-                        // for the identified business key and the business key name. This approach is chosen to 
-                        // ensure that the overall confidence reflects the weakest link, avoiding inflation of 
-                        // the confidence score when one value is significantly lower than the other.
-                        let confidence_score = identified_business_key.identified_business_key_values.confidence_value.min(business_key_name.business_key_name_values.confidence_value);
-                        let bk_name = &business_key_name.business_key_name_values.name;
-                        let bk_identified_reason = &identified_business_key.identified_business_key_values.reason;
-                        let bk_name_reason = &business_key_name.business_key_name_values.reason;
-                        let reason = format!("BK Identified Reason: {}, BK Naming Reason: {}", bk_identified_reason, bk_name_reason);
-                        let model_name_owned = guc::get_guc(guc::PgAutoDWGuc::Model).expect("MODEL GUC is not set.");
-                        let model_name = model_name_owned.as_str();
+                            let pk_source_objects: i32;
 
-                        let pk_source_objects: i32;   
-                        if let Some(pk_source_objects_temp) = table_column_links.find_pk_source_objects(column.clone() as i32) {
-                            pk_source_objects = pk_source_objects_temp;
-                        } else {
-                            println!("No match found for column_ordinal_position: {}", column);
-                            panic!()
-                        }
-
-                        if !last {
-                            insert_sql.push_str(&format!("({}, '{}', '{}', '{}', {}, '{}'),", pk_source_objects, model_name, category, bk_name.replace(" ", "_"), confidence_score, reason.replace("'", "''")));
-                        } else {
-                            insert_sql.push_str(&format!("({}, '{}', '{}', '{}', {}, '{}');", pk_source_objects, model_name, category, bk_name.replace(" ", "_"), confidence_score, reason.replace("'", "''")));
-                        }
-
-                    } else {
-
-                        let pk_source_objects: i32; 
-                        let mut category = "Descriptor";
-                        let mut confidence_score: f64 = 1.0;
-                        let bk_name = "NA";
-                        let mut reason = "Defaulted of category 'Descriptor' maintained.".to_string();
-                        let model_name_owned = guc::get_guc(guc::PgAutoDWGuc::Model).expect("MODEL GUC is not set.");
-                        let model_name = model_name_owned.as_str();
-                        
-
-                        if let Some(pk_source_objects_temp) = table_column_links.find_pk_source_objects(column.clone() as i32) {
-                            pk_source_objects = pk_source_objects_temp;
-                        } else {
-                            println!("No match found for column_ordinal_position: {}", column);
-                            panic!()
-                        }
-                        
-                        if let Some(descriptor_sensitive) = descriptors_sensitive.get(&column) {
-                            if descriptor_sensitive.descriptor_sensitive_values.is_pii && (descriptor_sensitive.descriptor_sensitive_values.confidence_value > 0.5) {
-                                category = "Descriptor - Sensitive";
-                                confidence_score = descriptor_sensitive.descriptor_sensitive_values.confidence_value;
-                                reason = descriptor_sensitive.descriptor_sensitive_values.reason.clone();
+                            if let Some(pk_source_objects_temp) = table_column_links.find_pk_source_objects(column.clone() as i32) {
+                                pk_source_objects = pk_source_objects_temp;
+                            } else {
+                                println!("No match found for column_ordinal_position: {}", column);
+                                panic!()
                             }
-                        } else {
-                            log!("Teseting Can't find a response for {} in Descriptors Sensitive Hashmap.", column);
+    
+                            if !last {
+                                insert_sql.push_str(&format!("({}, '{}', '{}', '{}', {}, '{}'),", pk_source_objects, model_name, category, bk_name.replace(" ", "_"), confidence_score, reason.replace("'", "''")));
+                            } else {
+                                insert_sql.push_str(&format!("({}, '{}', '{}', '{}', {}, '{}');", pk_source_objects, model_name, category, bk_name.replace(" ", "_"), confidence_score, reason.replace("'", "''")));
+                            }
+        
                         }
-
-                        if !last {
-                            insert_sql.push_str(&format!("({}, '{}', '{}', '{}', {}, '{}'),", pk_source_objects, model_name, category, bk_name.replace(" ", "_"), confidence_score, reason.replace("'", "''")));
-                        } else {
-                            insert_sql.push_str(&format!("({}, '{}', '{}', '{}', {}, '{}');", pk_source_objects, model_name, category, bk_name.replace(" ", "_"), confidence_score, reason.replace("'", "''")));
+                        _ => { // Not Identified as BKs
+                            let pk_source_objects: i32; 
+                            let mut category = "Descriptor";
+                            let mut confidence_score: f64 = 1.0;
+                            let bk_name = "NA";
+                            let mut reason = "Defaulted of category 'Descriptor' maintained.".to_string();
+                            let model_name_owned = guc::get_guc(guc::PgAutoDWGuc::Model).expect("MODEL GUC is not set.");
+                            let model_name = model_name_owned.as_str();
+                            
+                            if let Some(pk_source_objects_temp) = table_column_links.find_pk_source_objects(column.clone() as i32) {
+                                pk_source_objects = pk_source_objects_temp;
+                            } else {
+                                println!("No match found for column_ordinal_position: {}", column);
+                                panic!()
+                            }
+                            
+                            if let Some(descriptor_sensitive) = descriptors_sensitive.get(&column) {
+                                if descriptor_sensitive.descriptor_sensitive_values.is_pii && (descriptor_sensitive.descriptor_sensitive_values.confidence_value > 0.5) {
+                                    category = "Descriptor - Sensitive";
+                                    confidence_score = descriptor_sensitive.descriptor_sensitive_values.confidence_value;
+                                    reason = descriptor_sensitive.descriptor_sensitive_values.reason.clone();
+                                }
+                            } else {
+                                log!("Teseting Can't find a response for {} in Descriptors Sensitive Hashmap.", column);
+                            }
+    
+                            if !last {
+                                insert_sql.push_str(&format!("({}, '{}', '{}', '{}', {}, '{}'),", pk_source_objects, model_name, category, bk_name.replace(" ", "_"), confidence_score, reason.replace("'", "''")));
+                            } else {
+                                insert_sql.push_str(&format!("({}, '{}', '{}', '{}', {}, '{}');", pk_source_objects, model_name, category, bk_name.replace(" ", "_"), confidence_score, reason.replace("'", "''")));
+                            }
                         }
                     }
                 }

--- a/extension/src/controller/bgw_transformer_client.rs
+++ b/extension/src/controller/bgw_transformer_client.rs
@@ -46,8 +46,6 @@ pub extern "C" fn background_worker_transformer_client(_arg: pg_sys::Datum) {
                                                                                         table_column_links: table_column_links, 
                                                                                         table_details: table_details
                                                                                     };
-
-                        log!("Source Table Prompt:{:?}", source_table_prompt);
                         v_source_table_prompts.push(source_table_prompt)
                     }
                     Ok(v_source_table_prompts)
@@ -68,99 +66,57 @@ pub extern "C" fn background_worker_transformer_client(_arg: pg_sys::Datum) {
 
                 let columns = extract_column_numbers(&table_details_json_str);
 
-                // // Table Business Key Component Identification
-                // let mut generation_json_business_key_component_identification: Option<serde_json::Value> = None;
-                // let mut business_key_component_identification: HashMap<&u32, BusinessKeyComponentIdentification> = HashMap::new();
+                // Table Business Key Component Identification
+                let mut generation_json_business_key_component_identification: Option<serde_json::Value> = None;
+                let mut business_key_component_identification: HashMap<&u32, BusinessKeyComponentIdentification> = HashMap::new();
 
-                // for column in &columns {
-                //     let mut retries = 0;
-                //     let mut hints = String::new();
+                for column in &columns {
+                    let mut retries = 0;
+                    let mut hints = String::new();
 
-                //     while retries < MAX_TRANSFORMER_RETRIES {
-                //         runtime.block_on(async {
-                //             generation_json_business_key_component_identification = 
-                //                 match transformer_client::send_request(
-                //                     table_details_json_str.as_str(), 
-                //                     prompt_template::PromptTemplate::BKComponentIdentification, 
-                //                     column, 
-                //                     &hints).await {
-                //                 Ok(response_json) => {
+                    while retries < MAX_TRANSFORMER_RETRIES {
+                        runtime.block_on(async {
+                            generation_json_business_key_component_identification = 
+                                match transformer_client::send_request(
+                                    table_details_json_str.as_str(), 
+                                    prompt_template::PromptTemplate::BKComponentIdentification, 
+                                    column, 
+                                    &hints).await {
+                                Ok(response_json) => {
                                     
-                //                     let response_json_pretty = serde_json::to_string_pretty(&response_json)
-                //                                                                         .expect("Failed to convert Response JSON to Pretty String.");
-                                            
-                //                     log!("BK Component Identification Output: {response_json_pretty}");
+                                    let response_json_pretty = serde_json::to_string_pretty(&response_json)
+                                                                                        .expect("Failed to convert Response JSON to Pretty String.");
 
-                //                     Some(response_json)
-                //                 },
-                //                 Err(e) => {
-                //                     log!("Error in transformer request, malformed or timed out: {}", e);
-                //                     hints = format!("Hint: Please ensure you provide a JSON response only.  This is your {} attempt.", retries + 1);
-                //                     None
-                //                 }
-                //             };
-                //         });
+                                    Some(response_json)
+                                },
+                                Err(e) => {
+                                    log!("Error in transformer request, malformed or timed out: {}", e);
+                                    hints = format!("Hint: Please ensure you provide a JSON response only.  This is your {} attempt.", retries + 1);
+                                    None
+                                }
+                            };
+                        });
 
-                //         if generation_json_business_key_component_identification.is_none() {
-                //             retries += 1;
-                //             continue; // Skip to the next iteration
-                //         }
+                        if generation_json_business_key_component_identification.is_none() {
+                            retries += 1;
+                            continue; // Skip to the next iteration
+                        }
 
-                //         match serde_json::from_value::<BusinessKeyComponentIdentification>(generation_json_business_key_component_identification.clone().unwrap()) {
-                //             Ok(bki) => {
-                //                 // business_key_name_opt = Some(des);
-                //                 log!("Successfully Decoded: {:?}", bki);
-                //                 business_key_component_identification.insert(column, bki);
-                //                 break; // Successfully Decoded
-                //             }
-                //             Err(e) => {
-                //                 log!("Error JSON JSON Structure not of type DescriptorSensitive: {}", e);
-                //             }
-                //         }
+                        match serde_json::from_value::<BusinessKeyComponentIdentification>(generation_json_business_key_component_identification.clone().unwrap()) {
+                            Ok(bki) => {
+                                business_key_component_identification.insert(column, bki);
+                                break; // Successfully Decoded
+                            }
+                            Err(e) => {
+                                log!("Error JSON JSON Structure not of type DescriptorSensitive: {}", e);
+                            }
+                        }
+                        retries += 1;
+                        log!("{retries}");
+                    }
+                }
 
-                //         retries += 1;
-                //         log!("{retries}");
-                //     }
-                // }
-
-                
-                // let mut retries = 0;
-                // let mut hints = String::new();
-                // while retries < MAX_TRANSFORMER_RETRIES {
-                //     runtime.block_on(async {
-                //         // Get Generation
-                //         generation_json_table_classification = match transformer_client::send_request(table_details_json_str.as_str(), prompt_template::PromptTemplate::HubLinkClassification, &0, &hints).await {
-                //             Ok(response_json) => {
-                //                 Some(response_json)
-                //             },
-                //             Err(e) => {
-                //                 log!("Error in transformer request, malformed or timed out: {}", e);
-                //                 hints = format!("Hint: Please ensure you provide a JSON response only.  This is your {} attempt.", retries + 1);
-                //                 None
-                //             }
-                //         };
-                //     });
-
-                //     if generation_json_table_classification.is_none() {
-                //         retries += 1;
-                //         continue; // Skip to the next iteration
-                //     }
-
-                //     match serde_json::from_value::<TableClassification>(generation_json_table_classification.clone().unwrap()) {
-                //         Ok(bk) => {
-                //             table_classification_opt = Some(bk);
-                //             log!("Table Classification {:?}", table_classification_opt);
-                //             break; // Successfully Decoded
-                //         }
-                //         Err(e) => {
-                //             log!("Error JSON JSON Structure not of type IdentifiedBusinessKey: {}", e);
-                //             hints = format!("Hint: Please ensure the correct JSON key pair structure is given.  Previously you gave a response but it errored.  Error: {e}. Please try again.");
-                //         }
-                //     }
-                //     retries += 1;
-                // }
-
-
+                log!("BK Component Identification: {:?}", business_key_component_identification);
 
                 // Identity BK Ordinal Location
                 let mut generation_json_bk_identification: Option<serde_json::Value> = None;

--- a/extension/src/lib.rs
+++ b/extension/src/lib.rs
@@ -16,7 +16,6 @@ use model::queries;
 #[pg_extern(name="go")]
 fn go_default() -> String {
     let accepted_transformer_confidence_level: String = 
-        // utility::guc::get_guc(guc::PgAutoDWGuc::AcceptedTransformerConfidenceLevel).unwrap();
         utility::guc::get_guc(guc::PgAutoDWGuc::AcceptedTransformerConfidenceLevel)
             .unwrap_or_else(|| {
                 error!("GUC: Unable to obtain parameter \"pg_auto_dw.accepted_transformer_confidence_level.\"");

--- a/extension/src/model/prompt_template.rs
+++ b/extension/src/model/prompt_template.rs
@@ -1,7 +1,6 @@
 #[derive(Debug)]
 pub enum PromptTemplate {
     BKComponentIdentification,
-    BKIdentification,
     BKName,
     DescriptorSensitive,
 }
@@ -190,72 +189,6 @@ impl PromptTemplate {
             JSON Source Table Object: {new_json}
 
             Column No: {column_no}
-            "#,
-          PromptTemplate::BKIdentification => r#"
-            Task Title: Business Key Identification in JSON Source Table Object
-
-            You have a JSON Source Table Object that includes the schema name, table name, and detailed column information. Your responses to requested tasks will be used to help create downstream data vault tables.
-
-            Requested Task: Identify the column number most likely to serve as the business key. Return only one column in JSON format as specified below.
-
-
-            Request Details:
-            If the column is a primary key, assume it is the business key. If not, choose the column most likely to uniquely identify the table’s entity. Additionally, provide a confidence value for your selection.
-
-            Confidence Value: Provide a score between 0 and 1, rounded to two decimal places, representing your confidence in the selected column. A value of 0.80 or higher is considered reasonably confident.
-
-
-            Reason: Indicate why you made the decision you did.
-
-            Output: Ensure the output conforms to the format shown in the examples below.
-
-            Example Input 1)
-            JSON Source Table Object:
-            {
-              "Schema Name": "public",
-              "Table Name": "customer",
-              "Column Details": [
-                "Column No: 1 Named: customer_id of type: uuid And is a primary key.  Column Comments: NA",
-                "Column No: 2 Named: city of type: character varying(255) Column Comments: NA",
-                "Column No: 3 Named: state of type: character(2) Column Comments: NA",
-                "Column No: 4 Named: zip of type: character varying(10) Column Comments: NA"
-              ]
-            }
-
-            Example Output 1)
-            {
-              "Identified Business Key": {
-                "Column No": 1,
-                "Confidence Value": 0.95,
-                "Reason": "The 'customer_id' column is designated as the primary key, which is typically the best candidate for a business key."
-              }
-            }
-
-            Example Input 2)
-            JSON Source Table Object:
-            {
-              "Schema Name": "sales",
-              "Table Name": "order_details",
-              "Column Details": [
-                "Column No: 1 Named: order_id of type: integer Column Comments: NA",
-                "Column No: 2 Named: product_id of type: integer Column Comments: NA",
-                "Column No: 3 Named: quantity of type: integer Column Comments: NA",
-                "Column No: 4 Named: order_date of type: date Column Comments: NA"
-              ]
-            }
-
-            Example Output 2)
-            {
-              "Identified Business Key": {
-                "Column No": 1,
-                "Confidence Value": 0.75,
-                "Reason": "Although 'order_id' is not explicitly marked as a primary key, it is likely to uniquely identify each order, making it a strong candidate for the business key."
-              }
-            }
-
-            Now, based on the instructions and examples above, please generate the JSON output for the following input. {hints}
-
-            JSON Source Table Object: {new_json}
             "#,
           PromptTemplate::BKName => r#"
             Task Title: Business Key Naming in JSON Source Table Object with specified Column

--- a/extension/src/model/prompt_template.rs
+++ b/extension/src/model/prompt_template.rs
@@ -1,5 +1,6 @@
 #[derive(Debug)]
 pub enum PromptTemplate {
+    HubLinkClassification,
     BKIdentification,
     BKName,
     DescriptorSensitive,
@@ -8,6 +9,69 @@ pub enum PromptTemplate {
 impl PromptTemplate {
   pub fn template(&self) -> &str {
       match self {
+          PromptTemplate::HubLinkClassification => r#"
+            Task Title: Hub and Link Classification in JSON Source Table Object
+
+            You have a JSON Source Table Object that includes the schema name, table name, and detailed column information. Your responses to requested tasks will be used to help classify the source table as part of the data vault structure.
+
+            Requested Task:
+
+            Classify the source table as either a Hub or Link structure based on the column details provided. Additionally, provide a confidence value for your classification.
+
+            Confidence Value:
+
+            Provide a score between 0 and 1, rounded to two decimal places, representing your confidence in the classification. A value of 0.80 or higher is considered reasonably confident.
+
+            Reason:
+
+            Indicate why you made the classification decision you did.
+
+            Output:
+
+            Ensure the output conforms to the format shown in the examples below.
+
+            Example Input 1)
+            {
+              "Schema Name": "public",
+              "Table Name": "customer",
+              "Column Details": [
+                "Column No: 1 Named: customer_id of type: uuid And is a primary key. Column Comments: NA",
+                "Column No: 2 Named: city of type: character varying(255) Column Comments: NA",
+                "Column No: 3 Named: state of type: character(2) Column Comments: NA",
+                "Column No: 4 Named: zip of type: character varying(10) Column Comments: NA"
+              ]
+            }
+
+            Example Output 1)
+            {
+              "Classification": "Hub",
+              "Confidence Value": 0.92,
+              "Reason": "The 'customer_id' column is a primary key, and the table contains attributes likely describing a core entity, making it suitable for a Hub classification."
+            }
+
+            Example Input 2)
+            {
+              "Schema Name": "sales",
+              "Table Name": "order_details",
+              "Column Details": [
+                "Column No: 1 Named: order_id of type: integer Column Comments: NA",
+                "Column No: 2 Named: product_id of type: integer Column Comments: NA",
+                "Column No: 3 Named: quantity of type: integer Column Comments: NA",
+                "Column No: 4 Named: order_date of type: date Column Comments: NA"
+              ]
+            }
+
+            Example Output 2)
+            {
+              "Classification": "Link",
+              "Confidence Value": 0.85,
+              "Reason": "The 'order_id' and 'product_id' columns suggest a relationship between multiple tables, making this table a strong candidate for a Link classification."
+            }
+
+            Now, based on the instructions and examples above, please generate the appropriate JSON output only for the following JSON Source Table Object.  {hints}
+
+            JSON Source Table Object: {new_json}
+          "#,
           PromptTemplate::BKIdentification => r#"
             Task Title: Business Key Identification in JSON Source Table Object
 

--- a/extension/src/model/prompt_template.rs
+++ b/extension/src/model/prompt_template.rs
@@ -23,7 +23,7 @@ impl PromptTemplate {
 
             If the column is a primary key, as indicated in the comments or column details, assume it is a business key component. However, this does not exclude the possibility of other business key components within the table, but it may reduce the likelihood of the specified column being the only business key.
 
-            If the specified column could be categorized as an email, only consider it a business key component if there are no other attributes in the table that could reasonably serve as a business key component.
+            If the specified column could be categorized as an email or username, only consider it a business key component if there are no other attributes in the table that could reasonably serve as a business key component.
 
             Confidence Value:
 

--- a/extension/src/model/prompt_template.rs
+++ b/extension/src/model/prompt_template.rs
@@ -24,6 +24,8 @@ impl PromptTemplate {
 
             If the column is a primary key, as indicated in the comments or column details, assume it is a business key component. However, this does not exclude the possibility of other business key components within the table, but it may reduce the likelihood of the specified column being the only business key.
 
+            If the specified column could be categorized as an email, only consider it a business key component if there are no other attributes in the table that could reasonably serve as a business key component.
+
             Confidence Value:
 
             Provide a confidence score between 0 and 1, rounded to two decimal places, representing your confidence in the likelihood that the column is a business key component. A value of 0.80 or higher is considered reasonably confident.

--- a/extension/src/model/prompt_template.rs
+++ b/extension/src/model/prompt_template.rs
@@ -44,9 +44,11 @@ impl PromptTemplate {
 
             Example Output 1)
             {
-              "Classification": "Hub",
-              "Confidence Value": 0.92,
-              "Reason": "The 'customer_id' column is a primary key, and the table contains attributes likely describing a core entity, making it suitable for a Hub classification."
+              "Table Classification": {
+                "Classification": "Hub",
+                "Confidence Value": 0.92,
+                "Reason": "The 'customer_id' column is a primary key, and the table contains attributes likely describing a core entity, making it suitable for a Hub classification."
+              }
             }
 
             Example Input 2)
@@ -63,9 +65,11 @@ impl PromptTemplate {
 
             Example Output 2)
             {
-              "Classification": "Link",
-              "Confidence Value": 0.85,
-              "Reason": "The 'order_id' and 'product_id' columns suggest a relationship between multiple tables, making this table a strong candidate for a Link classification."
+              "Table Classification": {
+                "Classification": "Link",
+                "Confidence Value": 0.85,
+                "Reason": "The 'order_id' and 'product_id' columns suggest a relationship between multiple tables, making this table a strong candidate for a Link classification."
+              }
             }
 
             Now, based on the instructions and examples above, please generate the appropriate JSON output only for the following JSON Source Table Object.  {hints}


### PR DESCRIPTION
This pull request addresses the implementation of key functionalities related to detecting and processing all Business Key Components (BKC) on source tables, while continuing to process  only tables with a single BKC. The following changes have been made:

- feat(PADW-78): Enabled the GO function for cases where BKC equals 1, and implemented a hold for cases where BKC does not equal 1.
- chore(PADW-80): Removed unused business key identifier structures, as they have been replaced by the new business key component identifier structures.
- feat(PADW-80): Refactored the Incremental Descriptor Classifier to support multiple business keys, enhancing flexibility and scalability.
- feat(PADW-79): Integrated the Business Key Name Identifier into the Incremental BK Component Classifier to ensure accurate classification and identification of business key components.

Additional Completed Tasks:

- PADW-76: Added a new prompt template.
- PADW-77: Introduced a Transformer Backgrounder for adding the Incremental BK Component Classifier to improve classification consistency and accuracy across multiple tables.